### PR TITLE
fix: jitpack build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,9 +31,9 @@ dependencyManagement {
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	compileOnly 'org.projectlombok:lombok'
-	annotationProcessor 'org.projectlombok:lombok'
+	implementation 'org.springframework.boot:spring-boot-starter-web:3.1.2'
+	compileOnly 'org.projectlombok:lombok:1.1.26'
+	annotationProcessor 'org.projectlombok:lombok:1.18.26'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }


### PR DESCRIPTION
- jitpack에서 Invalid publication 'maven' 이 뜬 이유는 해당 프로젝트의 종속성에 대해 버전명시를 안해줬기 때문임